### PR TITLE
Django 1.7+ compatibility

### DIFF
--- a/django_commontranslations/management/commands/makemessages_unique.py
+++ b/django_commontranslations/management/commands/makemessages_unique.py
@@ -2,6 +2,7 @@
 import glob
 import os
 import polib
+from django import VERSION as DJANGO_VERSION
 from django.core.management.commands.makemessages import (
     Command as OriginalMakeMessagesCommand)
 from django.utils import translation
@@ -9,7 +10,11 @@ from django.utils.translation.trans_real import CONTEXT_SEPARATOR
 
 
 class Command(OriginalMakeMessagesCommand):
-    requires_model_validation = False
+    # Django version 1.7+ requires_model_validation is deprecated
+    # and the value of 'requires_system_checks' is used (which is defined in
+    # the original command). The attribute is completely removed in Django 1.9.
+    if DJANGO_VERSION < (1, 7):
+        requires_model_validation = False
     can_import_settings = True
 
     def handle_noargs(self, *args, **options):

--- a/django_commontranslations/management/commands/makemessages_unique.py
+++ b/django_commontranslations/management/commands/makemessages_unique.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import glob
-from django.utils.translation.trans_real import CONTEXT_SEPARATOR
-import polib
-from django.utils import translation
 import os
-from django.core.management.commands.makemessages import Command as OriginalMakeMessagesCommand
+import polib
+from django.core.management.commands.makemessages import (
+    Command as OriginalMakeMessagesCommand)
+from django.utils import translation
+from django.utils.translation.trans_real import CONTEXT_SEPARATOR
 
 
 class Command(OriginalMakeMessagesCommand):


### PR DESCRIPTION
Conditionally set deprecated attribute. See [Django 1.7 release notes for details]
(http://django.readthedocs.org/en/1.7.x/releases/1.7.html#django-core-management-basecommand).